### PR TITLE
Fix letter keyCode logic

### DIFF
--- a/distrib/host/control.js
+++ b/distrib/host/control.js
@@ -23,7 +23,7 @@
 //
 var TSOS;
 (function (TSOS) {
-    var Control = (function () {
+    var Control = /** @class */ (function () {
         function Control() {
         }
         Control.hostInit = function () {
@@ -99,6 +99,6 @@ var TSOS;
             // page from its cache, which is not what we want.
         };
         return Control;
-    })();
+    }());
     TSOS.Control = Control;
 })(TSOS || (TSOS = {}));

--- a/distrib/host/cpu.js
+++ b/distrib/host/cpu.js
@@ -15,7 +15,7 @@
      ------------ */
 var TSOS;
 (function (TSOS) {
-    var Cpu = (function () {
+    var Cpu = /** @class */ (function () {
         function Cpu(PC, Acc, Xreg, Yreg, Zflag, isExecuting) {
             if (PC === void 0) { PC = 0; }
             if (Acc === void 0) { Acc = 0; }
@@ -44,6 +44,6 @@ var TSOS;
             // Do the real work here. Be sure to set this.isExecuting appropriately.
         };
         return Cpu;
-    })();
+    }());
     TSOS.Cpu = Cpu;
 })(TSOS || (TSOS = {}));

--- a/distrib/host/devices.js
+++ b/distrib/host/devices.js
@@ -19,7 +19,7 @@
      ------------ */
 var TSOS;
 (function (TSOS) {
-    var Devices = (function () {
+    var Devices = /** @class */ (function () {
         function Devices() {
             _hardwareClockID = -1;
         }
@@ -56,6 +56,6 @@ var TSOS;
             }
         };
         return Devices;
-    })();
+    }());
     TSOS.Devices = Devices;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/canvastext.js
+++ b/distrib/os/canvastext.js
@@ -18,7 +18,7 @@
  * ----------------- */
 var TSOS;
 (function (TSOS) {
-    var CanvasTextFunctions = (function () {
+    var CanvasTextFunctions = /** @class */ (function () {
         function CanvasTextFunctions() {
         }
         CanvasTextFunctions.letter = function (ch) {
@@ -189,6 +189,6 @@ var TSOS;
             '~': { width: 24, points: [[3, 6], [3, 8], [4, 11], [6, 12], [8, 12], [10, 11], [14, 8], [16, 7], [18, 7], [20, 8], [21, 10], [-1, -1], [3, 8], [4, 10], [6, 11], [8, 11], [10, 10], [14, 7], [16, 6], [18, 6], [20, 7], [21, 10], [21, 12]] }
         };
         return CanvasTextFunctions;
-    })();
+    }());
     TSOS.CanvasTextFunctions = CanvasTextFunctions;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/console.js
+++ b/distrib/os/console.js
@@ -9,7 +9,7 @@
      ------------ */
 var TSOS;
 (function (TSOS) {
-    var Console = (function () {
+    var Console = /** @class */ (function () {
         function Console(currentFont, currentFontSize, currentXPosition, currentYPosition, buffer) {
             if (currentFont === void 0) { currentFont = _DefaultFontFamily; }
             if (currentFontSize === void 0) { currentFontSize = _DefaultFontSize; }
@@ -52,6 +52,7 @@ var TSOS;
                     // ... and add it to our buffer.
                     this.buffer += chr;
                 }
+                // TODO: Write a case for Ctrl-C.
             }
         };
         Console.prototype.putText = function (text) {
@@ -84,6 +85,6 @@ var TSOS;
             // TODO: Handle scrolling. (iProject 1)
         };
         return Console;
-    })();
+    }());
     TSOS.Console = Console;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/deviceDriver.js
+++ b/distrib/os/deviceDriver.js
@@ -5,17 +5,20 @@
      ------------------------------ */
 var TSOS;
 (function (TSOS) {
-    var DeviceDriver = (function () {
-        function DeviceDriver(driverEntry, isr) {
-            if (driverEntry === void 0) { driverEntry = null; }
-            if (isr === void 0) { isr = null; }
-            this.driverEntry = driverEntry;
-            this.isr = isr;
+    var DeviceDriver = /** @class */ (function () {
+        function DeviceDriver() {
             this.version = '0.07';
             this.status = 'unloaded';
             this.preemptable = false;
+            this.driverEntry = null;
+            this.isr = null;
+            // The constructor below is useless because child classes
+            // cannot pass "this" arguments when calling super().
+            //constructor(public driverEntry = null,
+            //            public isr = null) {
+            //}
         }
         return DeviceDriver;
-    })();
+    }());
     TSOS.DeviceDriver = DeviceDriver;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/deviceDriverKeyboard.js
+++ b/distrib/os/deviceDriverKeyboard.js
@@ -1,11 +1,15 @@
 ///<reference path="../globals.ts" />
 ///<reference path="deviceDriver.ts" />
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
-};
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
 /* ----------------------------------
    DeviceDriverKeyboard.ts
 
@@ -16,11 +20,18 @@ var __extends = (this && this.__extends) || function (d, b) {
 var TSOS;
 (function (TSOS) {
     // Extends DeviceDriver
-    var DeviceDriverKeyboard = (function (_super) {
+    var DeviceDriverKeyboard = /** @class */ (function (_super) {
         __extends(DeviceDriverKeyboard, _super);
         function DeviceDriverKeyboard() {
             // Override the base method pointers.
-            _super.call(this, this.krnKbdDriverEntry, this.krnKbdDispatchKeyPress);
+            var _this = 
+            // The code below cannot run because "this" can only be
+            // accessed after calling super.
+            //super(this.krnKbdDriverEntry, this.krnKbdDispatchKeyPress);
+            _super.call(this) || this;
+            _this.driverEntry = _this.krnKbdDriverEntry;
+            _this.isr = _this.krnKbdDispatchKeyPress;
+            return _this;
         }
         DeviceDriverKeyboard.prototype.krnKbdDriverEntry = function () {
             // Initialization routine for this, the kernel-mode Keyboard Device Driver.
@@ -34,26 +45,24 @@ var TSOS;
             _Kernel.krnTrace("Key code:" + keyCode + " shifted:" + isShifted);
             var chr = "";
             // Check to see if we even want to deal with the key that was pressed.
-            if (((keyCode >= 65) && (keyCode <= 90)) ||
-                ((keyCode >= 97) && (keyCode <= 123))) {
-                // Determine the character we want to display.
-                // Assume it's lowercase...
-                chr = String.fromCharCode(keyCode + 32);
-                // ... then check the shift key and re-adjust if necessary.
-                if (isShifted) {
-                    chr = String.fromCharCode(keyCode);
+            if ((keyCode >= 65) && (keyCode <= 90)) {
+                if (isShifted === true) {
+                    chr = String.fromCharCode(keyCode); // Uppercase A-Z
+                }
+                else {
+                    chr = String.fromCharCode(keyCode + 32); // Lowercase a-z
                 }
                 // TODO: Check for caps-lock and handle as shifted if so.
                 _KernelInputQueue.enqueue(chr);
             }
-            else if (((keyCode >= 48) && (keyCode <= 57)) ||
-                (keyCode == 32) ||
+            else if (((keyCode >= 48) && (keyCode <= 57)) || // digits
+                (keyCode == 32) || // space
                 (keyCode == 13)) {
                 chr = String.fromCharCode(keyCode);
                 _KernelInputQueue.enqueue(chr);
             }
         };
         return DeviceDriverKeyboard;
-    })(TSOS.DeviceDriver);
+    }(TSOS.DeviceDriver));
     TSOS.DeviceDriverKeyboard = DeviceDriverKeyboard;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/interrupt.js
+++ b/distrib/os/interrupt.js
@@ -3,12 +3,12 @@
    ------------ */
 var TSOS;
 (function (TSOS) {
-    var Interrupt = (function () {
+    var Interrupt = /** @class */ (function () {
         function Interrupt(irq, params) {
             this.irq = irq;
             this.params = params;
         }
         return Interrupt;
-    })();
+    }());
     TSOS.Interrupt = Interrupt;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/kernel.js
+++ b/distrib/os/kernel.js
@@ -13,7 +13,7 @@
      ------------ */
 var TSOS;
 (function (TSOS) {
-    var Kernel = (function () {
+    var Kernel = /** @class */ (function () {
         function Kernel() {
         }
         //
@@ -158,6 +158,6 @@ var TSOS;
             this.krnShutdown();
         };
         return Kernel;
-    })();
+    }());
     TSOS.Kernel = Kernel;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/queue.js
+++ b/distrib/os/queue.js
@@ -9,7 +9,7 @@
    ------------ */
 var TSOS;
 (function (TSOS) {
-    var Queue = (function () {
+    var Queue = /** @class */ (function () {
         function Queue(q) {
             if (q === void 0) { q = new Array(); }
             this.q = q;
@@ -38,6 +38,6 @@ var TSOS;
             return retVal;
         };
         return Queue;
-    })();
+    }());
     TSOS.Queue = Queue;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/shell.js
+++ b/distrib/os/shell.js
@@ -13,7 +13,7 @@
 // TODO: Write a base class / prototype for system services and let Shell inherit from it.
 var TSOS;
 (function (TSOS) {
-    var Shell = (function () {
+    var Shell = /** @class */ (function () {
         function Shell() {
             // Properties
             this.promptStr = ">";
@@ -247,6 +247,6 @@ var TSOS;
             }
         };
         return Shell;
-    })();
+    }());
     TSOS.Shell = Shell;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/shellCommand.js
+++ b/distrib/os/shellCommand.js
@@ -1,6 +1,6 @@
 var TSOS;
 (function (TSOS) {
-    var ShellCommand = (function () {
+    var ShellCommand = /** @class */ (function () {
         function ShellCommand(func, command, description) {
             if (command === void 0) { command = ""; }
             if (description === void 0) { description = ""; }
@@ -9,6 +9,6 @@ var TSOS;
             this.description = description;
         }
         return ShellCommand;
-    })();
+    }());
     TSOS.ShellCommand = ShellCommand;
 })(TSOS || (TSOS = {}));

--- a/distrib/os/userCommand.js
+++ b/distrib/os/userCommand.js
@@ -1,6 +1,6 @@
 var TSOS;
 (function (TSOS) {
-    var UserCommand = (function () {
+    var UserCommand = /** @class */ (function () {
         function UserCommand(command, args) {
             if (command === void 0) { command = ""; }
             if (args === void 0) { args = []; }
@@ -8,6 +8,6 @@ var TSOS;
             this.args = args;
         }
         return UserCommand;
-    })();
+    }());
     TSOS.UserCommand = UserCommand;
 })(TSOS || (TSOS = {}));

--- a/distrib/utils.js
+++ b/distrib/utils.js
@@ -5,7 +5,7 @@
    -------- */
 var TSOS;
 (function (TSOS) {
-    var Utils = (function () {
+    var Utils = /** @class */ (function () {
         function Utils() {
         }
         Utils.trim = function (str) {
@@ -31,11 +31,11 @@ var TSOS;
                 var ch = str[i];
                 var code = 0;
                 if ("abcedfghijklmABCDEFGHIJKLM".indexOf(ch) >= 0) {
-                    code = str.charCodeAt(i) + 13; // It's okay to use 13.  It's not a magic number, it's called rot13.
+                    code = str.charCodeAt(Number(i)) + 13; // It's okay to use 13.  It's not a magic number, it's called rot13.
                     retVal = retVal + String.fromCharCode(code);
                 }
                 else if ("nopqrstuvwxyzNOPQRSTUVWXYZ".indexOf(ch) >= 0) {
-                    code = str.charCodeAt(i) - 13; // It's okay to use 13.  See above.
+                    code = str.charCodeAt(Number(i)) - 13; // It's okay to use 13.  See above.
                     retVal = retVal + String.fromCharCode(code);
                 }
                 else {
@@ -45,6 +45,6 @@ var TSOS;
             return retVal;
         };
         return Utils;
-    })();
+    }());
     TSOS.Utils = Utils;
 })(TSOS || (TSOS = {}));

--- a/source/os/deviceDriverKeyboard.ts
+++ b/source/os/deviceDriverKeyboard.ts
@@ -38,14 +38,11 @@ module TSOS {
             _Kernel.krnTrace("Key code:" + keyCode + " shifted:" + isShifted);
             var chr = "";
             // Check to see if we even want to deal with the key that was pressed.
-            if (((keyCode >= 65) && (keyCode <= 90)) ||   // A..Z
-                ((keyCode >= 97) && (keyCode <= 123))) {  // a..z {
-                // Determine the character we want to display.
-                // Assume it's lowercase...
-                chr = String.fromCharCode(keyCode + 32);
-                // ... then check the shift key and re-adjust if necessary.
-                if (isShifted) {
-                    chr = String.fromCharCode(keyCode);
+            if ((keyCode >= 65) && (keyCode <= 90)) { // letter
+                if (isShifted === true) { 
+                    chr = String.fromCharCode(keyCode); // Uppercase A-Z
+                } else {
+                    chr = String.fromCharCode(keyCode + 32); // Lowercase a-z
                 }
                 // TODO: Check for caps-lock and handle as shifted if so.
                 _KernelInputQueue.enqueue(chr);


### PR DESCRIPTION
There exists a logical flaw in deviceDriverKeyboard.ts's krnKbdDispatchKeyPress(params). Our keyCode variable is confused with ASCII codes, and thus an unneeded (and erroneous) check for keyCodes 97-123 is made. Checking for keyCodes 97-123 is not only an extra check, but it also overlaps with other key presses (largely the numpad)