### PR TITLE
adds -g for gulp npm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ If your development environment does not then you'll need to automate the proces
 Setup Gulp
 ==========
 
-1. `npm install gulp` to get the Gulp Task Runner.
-1. `npm install gulp-tsc` to get the Gulp TypeScript plugin.
+1. `npm install -g gulp` to get the Gulp Task Runner.
+1. `npm install -g gulp-tsc` to get the Gulp TypeScript plugin.
 
 
 Run `gulp` at the command line in the root directory of this project.


### PR DESCRIPTION
`gulp` wasn't working because there's no `package.json` associated with the project. I realized that gulp should be installed globally. I hope to help some students out on that front.